### PR TITLE
Upgrade pmml4s to 1.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "pmml4s-spark"
 
-version := "0.9.16"
+version := "1.0.1"
 
 organization := "org.pmml4s"
 
@@ -20,7 +20,7 @@ scalacOptions in(Compile, doc) := Seq("-no-link-warnings")
 
 libraryDependencies ++= {
   Seq(
-    "org.pmml4s" %% "pmml4s" % "0.9.16",
+    "org.pmml4s" %% "pmml4s" % "1.0.1",
     "org.apache.spark" %% "spark-mllib" % "2.4.3" % "provided",
     "org.scalatest" %% "scalatest" % "3.0.1" % "test",
     "junit" % "junit" % "4.12" % "test"


### PR DESCRIPTION
Version `0.9.16` relies on `org.apache.commons:commons-text:1.6` which has some critical vulnerabilities. Version `1.0.1` uses `org.apache.commons:commons-text:1.10.0` which addresses those vulnerabilities.

What is the process to push that new version to maven ?

## Testing
I successfully compiled locally.